### PR TITLE
Added option to pick index of refraction in the Prescription Class

### DIFF
--- a/backend/blender_script/main.py
+++ b/backend/blender_script/main.py
@@ -9,17 +9,20 @@ from lens import Lens, LensPrescription, Prescription
 # initialize empty scene and spawn a lens in it with given parameters
 def startup():
     bpy.app.debug_wm = True
+    bpy.context.scene.render.engine = 'CYCLES'
 
     # spawn a lens pair
     prescription = Prescription(
                    left_eye= LensPrescription(5, 0, 0),
                    right_eye= LensPrescription(-5, 0, 0),
-                   pupillary_distance= 42 # mm
+                   pupillary_distance= 42, # mm
+                   index_of_refraction= 1.3
     )
 
     prescription.generate_lens_pair(context=bpy.context)
 
     # render scene
+    # currently creates a blend file with the generated lenses
     filepath = "./sample.blend"
     bpy.ops.wm.save_mainfile(filepath=filepath)
     return


### PR DESCRIPTION
The interface for Prescription class has a new parameter: index_of_refraction
![image](https://github.com/Lenscrafters-Capstone/LensCrafters-free/assets/32085355/5c267132-d0c0-4981-bfe2-59d50649d815)

This parameter is used when calculating radii of each lens. Currently only one ior is supported per lens pair. 

Also, when lenses are generated, they have the correct glass material. Here's a picture of the lenses when rendered with lighting:
![image](https://github.com/Lenscrafters-Capstone/LensCrafters-free/assets/32085355/87faa200-5da8-49ad-95d3-7aa58b3d0ccd)
