### PR TITLE
calculate weights and combine them in frontend

### DIFF
--- a/backend/blender_script/main.py
+++ b/backend/blender_script/main.py
@@ -1,4 +1,5 @@
 import bpy
+import bmesh
 import random
 import sys
 import os
@@ -8,6 +9,28 @@ from math import radians
 module_dir = os.path.dirname(__file__)
 sys.path.append(module_dir)
 from lens import Lens, LensPrescription, Prescription
+
+
+
+#densities are g per cubic meter
+# some densities taken from https://en.wikipedia.org/wiki/Corrective_lens
+IOR_Densities = {'Standard Plastic': 1390000, 
+                 'Polycarbonate': 1200000, 
+                 'High-index Plastic': 1270000, 
+                 'High-index Plastic': 1370000, 
+                 'High-index Plastic': 1470000, 
+                 'Crown Glass': 2590000, 
+                 'Flint Glass': 4400000}
+
+def calculate_weight(obj, density):
+    # Create a bmesh from the object's mesh data
+    bm = bmesh.new()
+    bm.from_mesh(obj.data)
+    # Calculate the volume
+    volume = bm.calc_volume(signed=True)
+    # Free the bmesh
+    bm.free()
+    return volume * density
 
 def insetLens():
 
@@ -58,7 +81,7 @@ def insetLens():
         lenscutter.select_set(False)
 
 # initialize empty scene and spawn a lens in it with given parameters
-def startup(SPHR, SPHL, CYLR, CYLL, AXISR, AXISL, IOR, frame, PD):
+def startup(SPHR, SPHL, CYLR, CYLL, AXISR, AXISL, IOR, frame, PD, MATERIAL):
     bpy.app.debug_wm = True
 
     # spawn a lens pair
@@ -75,6 +98,17 @@ def startup(SPHR, SPHL, CYLR, CYLL, AXISR, AXISL, IOR, frame, PD):
     lens_objects = bpy.context.scene.objects[-2:]
     lens_objects[0].name = "Lens_1"
     lens_objects[1].name = "Lens_2"
+    print(MATERIAL)
+    print(IOR_Densities[MATERIAL])
+    
+    lens1Weight = calculate_weight(lens_objects[0], IOR_Densities[MATERIAL])
+    lens2Weight = calculate_weight(lens_objects[1], IOR_Densities[MATERIAL])
+    print(lens1Weight)
+    print(lens2Weight)
+    with open('backend/lensWeight', 'w') as file:
+    # Write the float value to the file
+        file.write(str(round(lens1Weight+lens2Weight, 2)))
+    #weightFile = open("weights.csv", "w")
 
     insetLens()
     # Export lens pair
@@ -131,7 +165,7 @@ if __name__ == "__main__":
     print(sys.argv)
     if len(sys.argv) < 10:
         print('shouldnt be here')
-        startup(0.5, 0.5, 0, 0, 0, 0, 1.5, "aviator", 64)
+        startup(0.5, 0.5, 0, 0, 0, 0, 1.5, "aviator", 64, "Standard Plastic - 1.5")
     else:
         file_path = "backend/models/"+str(sys.argv[8])+"_inset.blend"
         bpy.ops.wm.read_factory_settings(use_empty=True)
@@ -144,5 +178,6 @@ if __name__ == "__main__":
                 float(sys.argv[6]), #AXISL
                 float(sys.argv[7]), #IOR
                 sys.argv[8], #frame
-                float(sys.argv[9]) #PD
+                float(sys.argv[9]), #PD
+                sys.argv[10] #MATERIAL
                 )

--- a/backend/blender_script/main.py
+++ b/backend/blender_script/main.py
@@ -14,13 +14,13 @@ from lens import Lens, LensPrescription, Prescription
 
 #densities are g per cubic meter
 # some densities taken from https://en.wikipedia.org/wiki/Corrective_lens
-IOR_Densities = {'Standard Plastic': 1390000, 
-                 'Polycarbonate': 1200000, 
-                 'High-index Plastic': 1270000, 
-                 'High-index Plastic': 1370000, 
-                 'High-index Plastic': 1470000, 
-                 'Crown Glass': 2590000, 
-                 'Flint Glass': 4400000}
+IOR_Densities = {'Standard Plastic1.5': 1390000, 
+                 'Polycarbonate1.59': 1200000, 
+                 'High-index Plastic1.57': 1270000, 
+                 'High-index Plastic1.67': 1370000, 
+                 'High-index Plastic1.74': 1470000, 
+                 'Crown Glass1.52': 2590000, 
+                 'Flint Glass1.6': 4400000}
 
 def calculate_weight(obj, density):
     # Create a bmesh from the object's mesh data
@@ -99,10 +99,10 @@ def startup(SPHR, SPHL, CYLR, CYLL, AXISR, AXISL, IOR, frame, PD, MATERIAL):
     lens_objects[0].name = "Lens_1"
     lens_objects[1].name = "Lens_2"
     print(MATERIAL)
-    print(IOR_Densities[MATERIAL])
+    print(str(MATERIAL) + str(IOR))
     
-    lens1Weight = calculate_weight(lens_objects[0], IOR_Densities[MATERIAL])
-    lens2Weight = calculate_weight(lens_objects[1], IOR_Densities[MATERIAL])
+    lens1Weight = calculate_weight(lens_objects[0], IOR_Densities[str(MATERIAL) + str(IOR)])
+    lens2Weight = calculate_weight(lens_objects[1], IOR_Densities[str(MATERIAL) + str(IOR)])
     print(lens1Weight)
     print(lens2Weight)
     with open('backend/lensWeight', 'w') as file:

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,3 +1,4 @@
+import os
 from flask import Flask, request, send_from_directory
 from flask_cors import CORS
 
@@ -18,18 +19,29 @@ def home():
 @app.route("/prescription", methods=["POST"])
 def prescription_input():
     prescription = request.get_json()
-    print(prescription)
+    print(prescription) 
     subprocess.run(["python3.10", "backend/blender_script/main.py", 
                     str(prescription["SPH_OD"]), str(prescription["SPH_OS"]), 
                     str(prescription["CYL_OD"]), str(prescription["CYL_OS"]), 
                     str(prescription["AXIS_OD"]), str(prescription["AXIS_OS"]), 
-                    str(prescription["IOR"]), prescription["FRAME_ID"], str(prescription["PD"])])
+                    str(prescription["IOR"]), prescription["FRAME_ID"], 
+                    str(prescription["PD"]), prescription["COMPOSITION"]])
     return "Done", 201
 
 
 @app.route('/get-model/<filename>', methods=['GET'])
 def get_glb(filename):
     return send_from_directory(GLB_DIRECTORY, filename)
+
+@app.route('/get-weight', methods=['GET'])
+def get_weight():
+    with open('./backend/lensWeight', 'r') as file:
+        # Read the content
+        content = file.read()
+        # Convert the content to float
+        float_value = float(content)
+        return str(float_value), 200
+
 
 
 if __name__ == "__main__":

--- a/frontend/src/pages/visualizeOptionsPage.js
+++ b/frontend/src/pages/visualizeOptionsPage.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Text, Flex, ActionIcon, Title, Paper, Button, Popover, Table, Divider } from '@mantine/core';
 import { Header } from '../components/header'
 import { IconChevronLeft, IconListCheck } from '@tabler/icons-react';
@@ -6,12 +6,39 @@ import { VisualizeCard } from '../components/visualizeCard';
 import { StepperBar } from '../components/stepperBar';
 import '@google/model-viewer/dist/model-viewer';
 
+
+
 export function VisualizeOptionsPage(props) {
-    const weight = {
-        lens: 70,
-        frame: 210,
-        combined: 280,
-    }
+    //weights found on https://www.eyebuydirect.ca/
+    //weight is in grams
+    let frameWeights = {
+        "Ray Ban Round Metal": 11,
+        "Ray Ban Aviator Classic": 12,
+        "Ray Ban Wayfarer Ease": 25
+    };
+
+    const [lensWeight, setLensWeight] = useState(null);
+
+    // Function to fetch lens weight
+    useEffect(() => {
+        async function fetchLensWeight() {
+            try {
+                const response = await fetch('http://localhost:5100/get-weight?' + String(Date.now()));
+                if (!response.ok) {
+                    throw new Error(`HTTP error! Status: ${response.status}`);
+                }
+                const weight = await response.text();
+                setLensWeight(parseFloat(weight));
+            } catch (error) {
+                console.error('Error fetching lens weight:', error);
+                // Handle error or set a default value
+                setLensWeight(0); // Example: setting to 0 on error
+            }
+        }
+
+        fetchLensWeight();
+    }, []);
+
     const {
         SPH_OD, SPH_OS, CYL_OD, CYL_OS, AXIS_OD, AXIS_OS, PD
     } = props.prescription;
@@ -96,11 +123,11 @@ export function VisualizeOptionsPage(props) {
                             WEIGHT
                         </Text>
                         <Text fw={600} size='md' mt='5em'> Lens Only</Text>
-                        <Text fw={400} size='md' mt='.5em'> {weight.lens}g</Text>
+                        <Text fw={400} size='md' mt='.5em'> {lensWeight}g</Text>
                         <Text fw={600} size='md' mt='3em'> Frames Only</Text>
-                        <Text fw={400} size='md' mt='.5em'> {weight.frame}g</Text>
+                        <Text fw={400} size='md' mt='.5em'> {frameWeights[props.frameName]}g</Text>
                         <Text fw={600} size='md' mt='3em'> Combined </Text>
-                        <Text fw={400} size='md' mt='.5em'> {weight.combined}g</Text>
+                        <Text fw={400} size='md' mt='.5em'> {(frameWeights[props.frameName] + lensWeight).toFixed(2)}g</Text>
                     </Paper>
                 </Flex>
             </Flex>

--- a/frontend/src/pages/visualizeOptionsPage.js
+++ b/frontend/src/pages/visualizeOptionsPage.js
@@ -143,9 +143,9 @@ export function VisualizeOptionsPage(props) {
                             WEIGHT
                         </Text>
                         <Text fw={600} size='md' mt='5em'> Lens Only</Text>
-                        <Text fw={400} size='md' mt='.5em'> {lensWeight}g</Text>
+                        <Text fw={400} size='md' mt='.5em'> {lensWeight ? lensWeight.toFixed(2) : lensWeight}g</Text>
                         <Text fw={600} size='md' mt='3em'> Frames Only</Text>
-                        <Text fw={400} size='md' mt='.5em'> {frameWeights[frameName]}g</Text>
+                        <Text fw={400} size='md' mt='.5em'> {(frameWeights[frameName]).toFixed(2)}g</Text>
                         <Text fw={600} size='md' mt='3em'> Combined </Text>
                         <Text fw={400} size='md' mt='.5em'> {(frameWeights[frameName] + lensWeight).toFixed(2)}g</Text>
                     </Paper>


### PR DESCRIPTION
Calculate the weights of lenses based on their density and volume.
Frame weights are static and stored in the frontend.
The combined weights are added in the frontend.
![image](https://github.com/Lenscrafters-Capstone/LensCrafters-free/assets/15898988/61e323c5-ee2e-4133-ad9e-65aadee077b5)
