### PR TITLE
Lens optimizations for thickness and optics

### DIFF
--- a/backend/blender_script/lens.py
+++ b/backend/blender_script/lens.py
@@ -542,7 +542,7 @@ class Lens():
         
         # use generated mesh for adding cylinder power when power is not 0
         # TODO: change condition, cylinder is currently disabled
-        self.cyl1 == 0
+        self.cyl1 = 0
         if self.cyl1 != 0:
             # create cylinder with radius corresponding to correct cylinder power
             # cylinder is already object, so no need to set it to variable

--- a/backend/blender_script/lens.py
+++ b/backend/blender_script/lens.py
@@ -97,7 +97,7 @@ class Prescription:
             # use base curve
             print("Using base curve")
             left_lens = Lens(rad1=base_curve_left_r, # base curve goes on front surface
-                            rad2=sphere_radius_bc,
+                            rad2= -sphere_radius_bc,
                             cyl1=0,
                             axis1= cylinder_axis,
                             location=location, 
@@ -143,7 +143,7 @@ class Prescription:
             # use base curve
             print("Using base curve")
             right_lens = Lens(rad1=base_curve_right, 
-                            rad2=sphere_radius_bc,
+                            rad2= -sphere_radius_bc,
                             cyl1=0,
                             axis1=0, 
                             location=location, 
@@ -584,7 +584,7 @@ class Lens():
             offset = self.location # offset for each lens's location
 
             dimensions = obj.dimensions
-            cyl.location = [-self.cyl1 - dimensions.x/2, 0, 0] # for now align with back surface
+            cyl.location = [-self.cyl1 - self.centerthickness/2, 0, 0] # for now align with back surface
             
             cyl.rotation_euler = [np.radians(self.axis1), 0, 0]
 

--- a/backend/blender_script/lens.py
+++ b/backend/blender_script/lens.py
@@ -112,7 +112,7 @@ class Prescription:
                             axis1= cylinder_axis,
                             location=location, 
                             lensradius=lens_radius, 
-                            centerthickness=0.01, 
+                            centerthickness=0.005, 
                             ior=ior)
             
         left_lens.add_lens(context=context)
@@ -158,7 +158,7 @@ class Prescription:
                             axis1=cylinder_axis, 
                             location=location, 
                             lensradius=lens_radius, 
-                            centerthickness=0.01, 
+                            centerthickness=0.005, 
                             ior=ior)
             
         right_lens.add_lens(context=context)

--- a/backend/blender_script/lens.py
+++ b/backend/blender_script/lens.py
@@ -92,6 +92,8 @@ class Prescription:
         '''
         if (abs(sphere_radius - base_curve_left_r) < 0.005):
             center_thickness = 0.0015 # 1.5mm
+        elif (sphere_radius == 0):
+            center_thickness = 0.0015 # 1.5mm
         
         if (left_prescription.cylinder == 0):
             # use base curve
@@ -123,7 +125,7 @@ class Prescription:
         location = [0, -bridge_dist - lens_radius, 0]
 
         base_curve_power_right = self.find_base_curve(right_prescription.sphere)
-        base_curve_right = self.convert_diopter_to_radius(diopter=base_curve_power_right, ior=ior)
+        base_curve_right_r = self.convert_diopter_to_radius(diopter=base_curve_power_right, ior=ior)
 
         # after finding base curve, compensate for it on the back surface
         sphere_power = right_prescription.sphere
@@ -136,13 +138,15 @@ class Prescription:
         cylinder_radius = self.convert_diopter_to_radius(diopter=right_prescription.cylinder, ior=ior)
         cylinder_axis = right_prescription.axis
         
-        if (abs(sphere_radius - base_curve_right) < 0.005):
+        if (abs(sphere_radius - base_curve_right_r) < 0.005):
+            center_thickness = 0.0015 # 1.5mm
+        elif (sphere_radius == 0):
             center_thickness = 0.0015 # 1.5mm
         
         if (right_prescription.cylinder == 0):
             # use base curve
             print("Using base curve")
-            right_lens = Lens(rad1=base_curve_right, 
+            right_lens = Lens(rad1=base_curve_right_r, 
                             rad2= -sphere_radius_bc,
                             cyl1=0,
                             axis1=0, 


### PR DESCRIPTION
Added a new method of generating lenses that should give better optics and thickness in general. However, that method is not compatible with the way we make cylindrical lenses, and so is not used when cylinder power is non-zero. 

The new method also doesn't fully work with the way lens insetting works, which results in lenses being placed slightly behind the frames, like this:
![image](https://github.com/Lenscrafters-Capstone/LensCrafters-free/assets/32085355/61b8c2aa-3299-4121-a2ea-9d21a493be43)

Also discovered some bugs with the cylinder generation code, namely it doesn't work well with a high sphere power. 